### PR TITLE
Added TabControlAdapter to use Prism Regions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ This project uses the following technologies:
   * **Dialog Service** as a Message Box
   * **Notification** pop-ups
   * **Prism Modules**
+  * **TabControlAdapter** - _Register a View as a TabItem using Prism's Region Navigation_
   * Exiting the main window in 2 flavors
 * WSL 2 - _with X11 rendering on Windows_
   * Execute using either Windows or Linux via WSL

--- a/source/SampleApp.Common/RegionNames.cs
+++ b/source/SampleApp.Common/RegionNames.cs
@@ -1,17 +1,19 @@
-﻿namespace SampleApp.Common
+﻿namespace SampleApp.Common;
+
+public static class RegionNames
 {
-  public static class RegionNames
-  {
-    /// <summary>Main Window's Footer Status Bar.</summary>
-    public const string FooterRegion = "FooterRegion";
+  /// <summary>Main Window's Footer Status Bar.</summary>
+  public const string FooterRegion = "FooterRegion";
 
-    /// <summary>Left Side Bar.</summary>
-    public const string LeftRegion = "LeftRegion";
+  /// <summary>Left Side Bar.</summary>
+  public const string LeftRegion = "LeftRegion";
 
-    /// <summary>Main Window's content region</summary>
-    public const string ContentRegion = "ContentRegion";
+  /// <summary>Main Window's content region.</summary>
+  public const string ContentRegion = "ContentRegion";
 
-    /// <summary>Right Side Bar.</summary>
-    public const string RightRegion = "RightRegion";
-  }
+  /// <summary>Mail module tab region.</summary>
+  public const string MailTabRegion = "MailTabRegion";
+
+  /// <summary>Right Side Bar.</summary>
+  public const string RightRegion = "RightRegion";
 }

--- a/source/SampleApp.Common/TabControlAdapter.cs
+++ b/source/SampleApp.Common/TabControlAdapter.cs
@@ -5,6 +5,10 @@ using Prism.Regions;
 
 namespace SampleApp.Common;
 
+/// <summary>
+///   Tab Control Adapter for hooking a UserControl as a TabItem
+///   * Tab Header: UserControl's `Tag` property 
+/// </summary>
 public class TabControlAdapter : RegionAdapterBase<TabControl>
 {
   public TabControlAdapter(IRegionBehaviorFactory regionBehaviorFactory) : base(regionBehaviorFactory)
@@ -17,18 +21,17 @@ public class TabControlAdapter : RegionAdapterBase<TabControl>
     {
       if (e.Action == NotifyCollectionChangedAction.Add)
       {
-        foreach (IControl item in e.NewItems)
+        foreach (UserControl item in e.NewItems)
         {
-          // TODO: Use 'Title' from the View.
           var items = regionTarget.Items.Cast<TabItem>().ToList();
-          items.Add(new TabItem { Header = item.Name, Content = item });
+          items.Add(new TabItem { Header = item.Tag, Content = item });
           regionTarget.Items = items;           // Avalonia v0.10.x
           //// regionTarget.Items.Set(items);   // Avalonia v11
         }
       }
       else if (e.Action == NotifyCollectionChangedAction.Remove)
       {
-        foreach (IControl item in e.OldItems)
+        foreach (UserControl item in e.OldItems)
         {
           var tabToDelete = regionTarget.Items.OfType<TabItem>().FirstOrDefault(n => n.Content == item);
           // regionTarget.Items.Remove(tabToDelete);  // WPF

--- a/source/SampleApp.Common/TabControlAdapter.cs
+++ b/source/SampleApp.Common/TabControlAdapter.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Specialized;
+using System.Linq;
+using Avalonia.Controls;
+using Prism.Regions;
+
+namespace SampleApp.Common;
+
+public class TabControlAdapter : RegionAdapterBase<TabControl>
+{
+  public TabControlAdapter(IRegionBehaviorFactory regionBehaviorFactory) : base(regionBehaviorFactory)
+  {
+  }
+
+  protected override void Adapt(IRegion region, TabControl regionTarget)
+  {
+    region.Views.CollectionChanged += (s, e) =>
+    {
+      if (e.Action == NotifyCollectionChangedAction.Add)
+      {
+        foreach (IControl item in e.NewItems)
+        {
+          // TODO: Use 'Title' from the View.
+          var items = regionTarget.Items.Cast<TabItem>().ToList();
+          items.Add(new TabItem { Header = item.Name, Content = item });
+          regionTarget.Items = items;           // Avalonia v0.10.x
+          //// regionTarget.Items.Set(items);   // Avalonia v11
+        }
+      }
+      else if (e.Action == NotifyCollectionChangedAction.Remove)
+      {
+        foreach (IControl item in e.OldItems)
+        {
+          var tabToDelete = regionTarget.Items.OfType<TabItem>().FirstOrDefault(n => n.Content == item);
+          // regionTarget.Items.Remove(tabToDelete);  // WPF
+
+          var items = regionTarget.Items.Cast<TabItem>().ToList();
+          items.Remove(tabToDelete);
+          regionTarget.Items = items;
+          //// regionTarget.Items.Set(items);   // Avalonia v11
+        }
+      }
+    };
+  }
+
+  protected override IRegion CreateRegion() => new SingleActiveRegion();
+}

--- a/source/SampleApp.Main/App.axaml.cs
+++ b/source/SampleApp.Main/App.axaml.cs
@@ -42,6 +42,7 @@ namespace SampleApp
       base.ConfigureRegionAdapterMappings(regionAdapterMappings);
       regionAdapterMappings.RegisterMapping(typeof(StackPanel), Container.Resolve<StackPanelRegionAdapter>());
       regionAdapterMappings.RegisterMapping(typeof(Grid), Container.Resolve<GridRegionAdapter>());
+      regionAdapterMappings.RegisterMapping(typeof(TabControl), Container.Resolve<TabControlAdapter>());
     }
 
     protected override IAvaloniaObject CreateShell()
@@ -68,6 +69,7 @@ namespace SampleApp
       containerRegistry.Register<MainWindow>();
       containerRegistry.Register<StackPanelRegionAdapter>();
       containerRegistry.Register<GridRegionAdapter>();
+      ////containerRegistry.Register<TabControlAdapter>();
 
       // Views - Region Navigation
       containerRegistry.RegisterForNavigation<DashboardView, DashboardViewModel>();

--- a/source/SampleApp.Modules.Mail/MailModule.cs
+++ b/source/SampleApp.Modules.Mail/MailModule.cs
@@ -13,9 +13,13 @@ public class MailModule : IModule
   public void OnInitialized(IContainerProvider containerProvider)
   {
     var regionManager = containerProvider.Resolve<IRegionManager>();
+    
+    // Main Window's Content Region
     regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(MailView));
-    regionManager.RegisterViewWithRegion("MailTabRegion", typeof(MailFocusedView));
-    regionManager.RegisterViewWithRegion("MailTabRegion", typeof(MailOtherView));
+    
+    // Mail Module's Tab Region
+    regionManager.RegisterViewWithRegion(RegionNames.MailTabRegion, typeof(MailFocusedView));
+    regionManager.RegisterViewWithRegion(RegionNames.MailTabRegion, typeof(MailOtherView));
   }
 
   public void RegisterTypes(IContainerRegistry containerRegistry)

--- a/source/SampleApp.Modules.Mail/MailModule.cs
+++ b/source/SampleApp.Modules.Mail/MailModule.cs
@@ -14,6 +14,8 @@ public class MailModule : IModule
   {
     var regionManager = containerProvider.Resolve<IRegionManager>();
     regionManager.RegisterViewWithRegion(RegionNames.ContentRegion, typeof(MailView));
+    regionManager.RegisterViewWithRegion("MailTabRegion", typeof(MailFocusedView));
+    regionManager.RegisterViewWithRegion("MailTabRegion", typeof(MailOtherView));
   }
 
   public void RegisterTypes(IContainerRegistry containerRegistry)

--- a/source/SampleApp.Modules.Mail/ViewModels/MailFocusedViewModel.cs
+++ b/source/SampleApp.Modules.Mail/ViewModels/MailFocusedViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.ObjectModel;
+using SampleApp.Common;
+using SampleApp.Common.Models;
+using SampleApp.Services;
+
+namespace SampleApp.Modules.Mail.ViewModels;
+
+public class MailFocusedViewModel : ViewModelBase
+{
+  private IMailService _mailService;
+
+  public MailFocusedViewModel(IMailService mailService)
+  {
+    _mailService = mailService;
+
+    MailMessages = new ObservableCollection<MailMessage>(_mailService.Messages);
+  }
+
+  public ObservableCollection<MailMessage> MailMessages { get; private set; }
+}

--- a/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml
@@ -4,9 +4,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SampleApp.Modules.Mail.ViewModels"
              x:Class="SampleApp.Modules.Mail.Views.MailFocusedView"
-             x:Name="FocusedView"
              d:DesignHeight="200"
              d:DesignWidth="400"
+             Tag="Focused"
              mc:Ignorable="d">
   <ListBox Margin="2"
            Items="{Binding MailMessages}"

--- a/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:SampleApp.Modules.Mail.ViewModels"
+             x:Class="SampleApp.Modules.Mail.Views.MailFocusedView"
+             x:Name="FocusedView"
+             d:DesignHeight="200"
+             d:DesignWidth="400"
+             mc:Ignorable="d">
+  <ListBox Margin="2"
+           Items="{Binding MailMessages}"
+           ScrollViewer.HorizontalScrollBarVisibility="Visible"
+           ScrollViewer.VerticalScrollBarVisibility="Visible"
+           SelectionMode="Single">
+    <ListBox.DataTemplates>
+      <DataTemplate>
+        <StackPanel Orientation="Horizontal" Spacing="5">
+          <TextBlock Text="From:" FontWeight="Bold" />
+          <TextBlock Text="{Binding From}" />
+          <TextBlock Text=" - " />
+          <TextBlock Text="{Binding Subject}" />
+        </StackPanel>
+      </DataTemplate>
+    </ListBox.DataTemplates>
+  </ListBox>
+</UserControl>

--- a/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml.cs
+++ b/source/SampleApp.Modules.Mail/Views/MailFocusedView.axaml.cs
@@ -3,9 +3,9 @@ using Avalonia.Markup.Xaml;
 
 namespace SampleApp.Modules.Mail.Views;
 
-public partial class MailView : UserControl
+public partial class MailFocusedView : UserControl
 {
-  public MailView()
+  public MailFocusedView()
   {
     InitializeComponent();
   }

--- a/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SampleApp.Modules.Mail.ViewModels"
              x:Class="SampleApp.Modules.Mail.Views.MailOtherView"
+             Tag="Other Items"
              x:Name="OtherView"
              d:DesignHeight="200"
              d:DesignWidth="400"

--- a/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:SampleApp.Modules.Mail.ViewModels"
+             x:Class="SampleApp.Modules.Mail.Views.MailOtherView"
+             x:Name="OtherView"
+             d:DesignHeight="200"
+             d:DesignWidth="400"
+             mc:Ignorable="d">
+  <Label Content="(Empty)" FontStyle="Italic" />
+</UserControl>

--- a/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml.cs
+++ b/source/SampleApp.Modules.Mail/Views/MailOtherView.axaml.cs
@@ -3,9 +3,9 @@ using Avalonia.Markup.Xaml;
 
 namespace SampleApp.Modules.Mail.Views;
 
-public partial class MailView : UserControl
+public partial class MailOtherView : UserControl
 {
-  public MailView()
+  public MailOtherView()
   {
     InitializeComponent();
   }

--- a/source/SampleApp.Modules.Mail/Views/MailView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailView.axaml
@@ -24,31 +24,11 @@
     
     <Grid Grid.Row="1">
       <Border Grid.Column="0" Classes="ControlBorder">
-
-        <TabControl>
-          <TabItem Header="Focused">
-            <ListBox Margin="2"
-                     Items="{Binding MailMessages}"
-                     ScrollViewer.HorizontalScrollBarVisibility="Visible"
-                     ScrollViewer.VerticalScrollBarVisibility="Visible"
-                     SelectionMode="Single">
-              <ListBox.DataTemplates>
-                <DataTemplate>
-                  <StackPanel Orientation="Horizontal" Spacing="5">
-                    <TextBlock Text="From:" FontWeight="Bold" />
-                    <TextBlock Text="{Binding From}" />
-                    <TextBlock Text=" - " />
-                    <TextBlock Text="{Binding Subject}" />
-                  </StackPanel>
-                </DataTemplate>
-              </ListBox.DataTemplates>
-            </ListBox>
-          </TabItem>
-
-          <TabItem Header="Other">
-            <Label Content="(Empty)" FontStyle="Italic" />
-          </TabItem>
-        </TabControl>
+        <TabControl Margin="5"
+                    prism:RegionManager.RegionName="MailTabRegion"
+                    VerticalAlignment="Stretch"
+                    HorizontalAlignment="Stretch"
+                    BorderThickness="1" />
       </Border>
     </Grid>
   </Grid>

--- a/source/SampleApp.Modules.Mail/Views/MailView.axaml
+++ b/source/SampleApp.Modules.Mail/Views/MailView.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:core="clr-namespace:SampleApp.Common;assembly=SampleApp.Common"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:prism="http://prismlibrary.com/"
@@ -19,15 +20,17 @@
 
     <StackPanel Orientation="Horizontal" Spacing="5">
       <Button Command="{Binding CommandShowDashboard}" Content="&lt; Dashboard" />
-      <Label Content="{Binding Greeting}" FontWeight="Bold" VerticalAlignment="Center" />
+      <Label VerticalAlignment="Center"
+             Content="{Binding Greeting}"
+             FontWeight="Bold" />
     </StackPanel>
-    
+
     <Grid Grid.Row="1">
       <Border Grid.Column="0" Classes="ControlBorder">
-        <TabControl Margin="5"
-                    prism:RegionManager.RegionName="MailTabRegion"
-                    VerticalAlignment="Stretch"
+        <TabControl prism:RegionManager.RegionName="{x:Static core:RegionNames.MailTabRegion}"
+                    Margin="5"
                     HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
                     BorderThickness="1" />
       </Border>
     </Grid>


### PR DESCRIPTION
Added a **TabControl Adapter** for using Prism's RegionAdapter. This example shows users how to register Views as a `TabItem` in the `TabControl` with its own unique ViewModel.

## References
* https://www.youtube.com/watch?v=BXeIZgssP0A
* https://github.com/NathanielACollier/dotnetLib_nac.Forms/blob/master/nac.Forms/Form.Tabs.cs